### PR TITLE
Link libcrypto explicitly to build with gold linker

### DIFF
--- a/configure
+++ b/configure
@@ -1562,7 +1562,7 @@ if test x$enableval = xyes ; then
 #define HAVE_SSL 1
 EOF
 
-	LIBS="$LIBS -lssl"
+	LIBS="$LIBS -lssl -lcrypto"
 fi
 enableval=""
 

--- a/configure.in
+++ b/configure.in
@@ -52,7 +52,7 @@ AC_ARG_ENABLE(ssl,
 [  --enable-ssl           support for secure connection to mail server])
 if test x$enableval = xyes ; then
 	AC_DEFINE(HAVE_SSL)
-	LIBS="$LIBS -lssl"
+	LIBS="$LIBS -lssl -lcrypto"
 fi
 enableval=""
 


### PR DESCRIPTION
ssmtp fails to link with the gold linker because it requires that all libraries that are used be explicitly passed to the linker with the -l flag. In particular, the following error occurs during linking:

i686-pc-linux-gnu-gcc -L/build/x86-generic/lib -L/build/x86-generic/usr/lib -o ssmtp ssmtp.o arpadate.o base64.o xgethostname.o  -lssl -DPACKAGE_NAME=\"\" -DPACKAGE_TARNAME=\"\" -DPACKAGE_VERSION=\"\" -DPACKAGE_STRING=\"\" -DPACKAGE_BUGREPORT=\"\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_LIMITS_H=1 -DHAVE_STRINGS_H=1 -DHAVE_SYSLOG_H=1 -DHAVE_UNISTD_H=1 -DRETSIGTYPE=void -DHAVE_VPRINTF=1 -DHAVE_GETHOSTNAME=1 -DHAVE_SOCKET=1 -DHAVE_STRDUP=1 -DHAVE_STRNDUP=1 -DHAVE_STRSTR=1 -DREWRITE_DOMAIN=1 -DHAVE_SSL=1 -DSSMTPCONFDIR=\"/etc/ssmtp\"
-DCONFIGURATION_FILE=\"/etc/ssmtp/ssmtp.conf\"
-DREVALIASES_FILE=\"/etc/ssmtp/revaliases\"  -O2 -pipe -march=core2 -mtune=generic -mfpmath=sse
-I/build/x86-generic/usr/include/ -I/build/x86-generic/include/ -gstabs /usr/libexec/gcc/i686-pc-linux-gnu/ld: ssmtp.o: in function smtp_open: ssmtp.c(.text+0x1cf9): error: undefined reference to 'X509_free'

This can be fixed by passing the crypto library explicitly when the ssl library is used. See patch attached.

Reproducible: Always
Source: https://bugs.gentoo.org/337730