### PR TITLE
Reset buffer memory after allocation.

### DIFF
--- a/ssmtp.c
+++ b/ssmtp.c
@@ -778,6 +778,7 @@ void header_parse(FILE *stream)
 			if(p == (char *)NULL) {
 				die("header_parse() -- realloc() failed");
 			}
+			memset(p, 0, (size * sizeof(char)));
 			q = (p + len);
 		}
 		len++;


### PR DESCRIPTION
## Description
ssmtp sends parts of its own config file on invalid inputs due to un-initialized memory buffer. 

## Related Ticket
Fixes #5

## Checklist
- [x] I have performed a self-review of my code
- [x] Documentation updated
